### PR TITLE
Add watchOS deployment target to the podspec

### DIFF
--- a/emojidataios.podspec
+++ b/emojidataios.podspec
@@ -22,6 +22,7 @@ Parses your emojis from Unicode to aliases, and vice versa. Based on emoji-data
   s.social_media_url = 'https://twitter.com/maxoumime'
 
   s.ios.deployment_target = '8.0'
+  s.watchos.deployment_target = '5.0'
 
   s.source_files = 'emojidataios/Classes/**/*'
   


### PR DESCRIPTION
Hi There,

Would be great to use emoji-data-ios with watchOS as well as iOS - have added a watchOS deployment target to the podspec, and validated it building with Xcode 11.

Thanks, all the best.